### PR TITLE
Automatic renewal of CXX MDR Token

### DIFF
--- a/src/main/java/de/uzl/lied/mtbimporter/jobs/mdr/centraxx/CxxMdrAttributes.java
+++ b/src/main/java/de/uzl/lied/mtbimporter/jobs/mdr/centraxx/CxxMdrAttributes.java
@@ -18,6 +18,11 @@ import de.uzl.lied.mtbimporter.settings.CxxMdrSettings;
 public class CxxMdrAttributes {
 
     public static ClinicalHeader getAttributes(CxxMdrSettings mdr, String mdrProfile, String key) {
+
+        if (mdr.isTokenExpired()) {
+            CxxMdrLogin.login(mdr);
+        }
+
         MultiValueMap<String, String> form = new LinkedMultiValueMap<String, String>();
         form.set("code", mdrProfile);
         form.set("domainCode", "cbioportal");

--- a/src/main/java/de/uzl/lied/mtbimporter/jobs/mdr/centraxx/CxxMdrConvert.java
+++ b/src/main/java/de/uzl/lied/mtbimporter/jobs/mdr/centraxx/CxxMdrConvert.java
@@ -12,13 +12,17 @@ public class CxxMdrConvert {
 
     public static RelationConvert convert(CxxMdrSettings mdr, RelationConvert input) {
 
+        if (mdr.isTokenExpired()) {
+            CxxMdrLogin.login(mdr);
+        }
+
         RestTemplate rt = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString());
         headers.add(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.toString());
         headers.add("Authorization", "Bearer " + mdr.getToken());
-        return rt.postForObject(mdr.getUrl() + "/rest/v1/relations/convert",
-                new HttpEntity<>(input, headers), RelationConvert.class);
+        return rt.postForObject(mdr.getUrl() + "/rest/v1/relations/convert", new HttpEntity<>(input, headers),
+                RelationConvert.class);
 
     }
 


### PR DESCRIPTION
Token acquired from the MDR are only valid for limited time. Usually this is 1800s, but can vary due to configuration. Therefore the token validity could already be checked before. 
This PR adds an additional login to the MDR if the currently stored token is expired.