### PR TITLE
Fix timeline map

### DIFF
--- a/src/main/java/de/uzl/lied/mtbimporter/model/CbioPortalStudy.java
+++ b/src/main/java/de/uzl/lied/mtbimporter/model/CbioPortalStudy.java
@@ -277,11 +277,11 @@ public class CbioPortalStudy {
     }
 
     public <T> void addTimeline(Class<T> timeline, Timeline entry) {
-        this.timeline.put(timeline.getClass(), Timeline.merge(this.timeline.getOrDefault(timeline, new ArrayList<Timeline>()), List.of(entry)));
+        this.timeline.put(timeline, Timeline.merge(this.timeline.getOrDefault(timeline, new ArrayList<Timeline>()), List.of(entry)));
     }
 
     public <T> void addTimeline(Class<T> timeline, Collection<Timeline> entries) {
-        this.timeline.put(timeline.getClass(), Timeline.merge(this.timeline.getOrDefault(timeline, new ArrayList<Timeline>()), entries));
+        this.timeline.put(timeline, Timeline.merge(this.timeline.getOrDefault(timeline, new ArrayList<Timeline>()), entries));
     }
 
     public Map<Class, List<Timeline>> getTimelines() {


### PR DESCRIPTION
As several different types of timeline are supported, the JVM class is used as Key for the corresponding HashMap structure. This accidently used `*.class` which lead to use the Generic Java class and therefore overwriting the previous list. This PR fixes that behavior.